### PR TITLE
Bumped lambda_http from 0.15 to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ lambda = ["dep:http", "dep:lambda_http", "dep:lambda_runtime", "dep:pin-project"
 
 [dependencies]
 http = { version = "1.0", optional = true }
-lambda_http = { version = "0.15", optional = true }
+lambda_http = { version = "0.16", optional = true }
 lambda_runtime = { version = "0.14", optional = true }
 metrics = "0.24"
 pin-project = { version = "1", optional = true }

--- a/examples/lambda-http/Cargo.toml
+++ b/examples/lambda-http/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-lambda_http = { version = "0.15", default-features = false, features = ["apigw_http"] }
+lambda_http = { version = "0.16", default-features = false, features = ["apigw_http"] }
 lambda_runtime = "0.14"
 metrics = "0.24"
 metrics_cloudwatch_embedded = { path = "../..", features = ["lambda"] }


### PR DESCRIPTION
This pull request updates the `lambda_http` dependency to version 0.16 in both the main project and the example project. This ensures compatibility with the latest features and fixes from the `lambda_http` crate.

Dependency updates:

* Updated `lambda_http` dependency from version 0.15 to 0.16 in the main `Cargo.toml` file.
* Updated `lambda_http` dependency from version 0.15 to 0.16 in the `examples/lambda-http/Cargo.toml` file.